### PR TITLE
Add log format config and unify logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,6 @@ GC_ADB_HOST=127.0.0.1
 GC_ADB_PORT=5557
 JOB_DB_PATH=jobs.sqlite
 LOG_LEVEL=INFO
+LOG_FORMAT=%(asctime)s %(levelname)s %(name)s: %(message)s
 LOG_FILE=
 WORKER_COUNT=1

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The application loads its configuration from environment variables. The most imp
 - `GC_ADB_HOST` / `GC_ADB_PORT` – address of the device with GetContact.
 - `JOB_DB_PATH` – path to the SQLite file storing job statuses.
 - `LOG_LEVEL` – logging verbosity (e.g. `INFO`, `DEBUG`).
+- `LOG_FORMAT` – Python logging format string.
 - `LOG_FILE` – optional path to a file where logs will be written.
 - `WORKER_COUNT` – how many background workers process jobs.
 

--- a/api.py
+++ b/api.py
@@ -41,7 +41,11 @@ async def get_api_key(api_key: str = Security(api_key_header)) -> str:
     return api_key
 
 
-configure_logging(level=settings.log_level, log_file=settings.log_file)
+configure_logging(
+    level=settings.log_level,
+    fmt=settings.log_format,
+    log_file=settings.log_file,
+)
 logger = logging.getLogger(__name__)
 
 job_manager = JobManager(settings.job_db_path)

--- a/phone_spam_checker/cli_base.py
+++ b/phone_spam_checker/cli_base.py
@@ -57,7 +57,11 @@ def parse_common_args(
 
 def run_checker(service: str, argv: list[str] | None = None) -> int:
     """Run a checker identified by name with CLI arguments."""
-    configure_logging(level=settings.log_level)
+    configure_logging(
+        level=settings.log_level,
+        fmt=settings.log_format,
+        log_file=settings.log_file,
+    )
     args = parse_common_args(argv, description=f"Phone number lookup via {service}")
 
     if not args.input.exists():

--- a/phone_spam_checker/config.py
+++ b/phone_spam_checker/config.py
@@ -22,6 +22,7 @@ class Settings:
     gc_adb_port: str = "5557"
     job_db_path: str = "jobs.sqlite"
     log_level: str = "INFO"
+    log_format: str = "%(asctime)s %(levelname)s %(name)s: %(message)s"
     log_file: str | None = None
     worker_count: int = 1
 
@@ -37,6 +38,9 @@ class Settings:
             gc_adb_port=_getenv("GC_ADB_PORT", "5557"),
             job_db_path=_getenv("JOB_DB_PATH", "jobs.sqlite"),
             log_level=_getenv("LOG_LEVEL", "INFO"),
+            log_format=_getenv(
+                "LOG_FORMAT", "%(asctime)s %(levelname)s %(name)s: %(message)s"
+            ),
             log_file=_getenv("LOG_FILE", "") or None,
             worker_count=int(_getenv("WORKER_COUNT", "1")),
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,15 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 os.environ.setdefault("API_KEY", "testkey")
 
+from phone_spam_checker.logging_config import configure_logging
+from phone_spam_checker.config import settings
+
+configure_logging(
+    level=settings.log_level,
+    fmt=settings.log_format,
+    log_file=settings.log_file,
+)
+
 import api
 
 
@@ -69,7 +78,9 @@ def test_submit_check(monkeypatch):
 
 
 def test_get_status(monkeypatch):
-    results = [api.CheckResult(phone_number="123", status=api.CheckStatus.SAFE, details="")]
+    results = [
+        api.CheckResult(phone_number="123", status=api.CheckStatus.SAFE, details="")
+    ]
     job_data = {
         "job123": {
             "status": "completed",
@@ -93,7 +104,9 @@ def test_get_status(monkeypatch):
 
 async def _dummy_run_check(job_id, numbers, service):
     manager = api.job_manager
-    results = [api.CheckResult(phone_number=n, status=api.CheckStatus.SAFE) for n in numbers]
+    results = [
+        api.CheckResult(phone_number=n, status=api.CheckStatus.SAFE) for n in numbers
+    ]
     manager.complete_job(job_id, results)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,21 @@
 import sys
 import types
+
 sys.modules.setdefault("uiautomator2", types.ModuleType("uiautomator2"))
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+from phone_spam_checker.logging_config import configure_logging
+from phone_spam_checker.config import settings
+
+configure_logging(
+    level=settings.log_level,
+    fmt=settings.log_format,
+    log_file=settings.log_file,
+)
 
 import phone_checker_cli
 from phone_spam_checker import cli_base
@@ -23,5 +33,3 @@ def test_cli_dispatch(monkeypatch):
     monkeypatch.setattr(phone_checker_cli, "run_checker", fake_run)
     assert phone_checker_cli.main(["kaspersky", "-i", "f.txt"]) == 123
     assert called == {"service": "kaspersky", "argv": ["-i", "f.txt"]}
-
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,12 +6,24 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from phone_spam_checker.logging_config import configure_logging
+from phone_spam_checker.config import settings
+
+configure_logging(
+    level=settings.log_level,
+    fmt=settings.log_format,
+    log_file=settings.log_file,
+)
+
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "phone_spam_checker" / "config.py"
+
+
 def load_config():
     spec = util.spec_from_file_location("config", CONFIG_PATH)
     module = util.module_from_spec(spec)
     spec.loader.exec_module(module)  # type: ignore
     return module
+
 
 config = load_config()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,15 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from phone_spam_checker.logging_config import configure_logging
+from phone_spam_checker.config import settings
+
+configure_logging(
+    level=settings.log_level,
+    fmt=settings.log_format,
+    log_file=settings.log_file,
+)
+
 from phone_spam_checker.utils import read_phone_list, write_results  # noqa: E402
 from phone_spam_checker.domain.models import PhoneCheckResult, CheckStatus  # noqa: E402
 
@@ -21,7 +30,9 @@ def test_read_phone_list(tmp_path: Path) -> None:
 
 def test_write_results(tmp_path: Path) -> None:
     file = tmp_path / "out.csv"
-    results = [PhoneCheckResult(phone_number="123", status=CheckStatus.SPAM, details="bad")]
+    results = [
+        PhoneCheckResult(phone_number="123", status=CheckStatus.SPAM, details="bad")
+    ]
     write_results(file, results)
     with file.open(encoding="utf-8") as f:
         reader = list(csv.DictReader(f))


### PR DESCRIPTION
## Summary
- allow configuring log format via settings
- document LOG_FORMAT variable
- unify configure_logging usage in API, CLI and tests
- update example environment file

## Testing
- `pyenv shell 3.10.17 && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841804b52b483278971fe1c28eb439d