### PR TITLE
Refactor job manager with repository

### DIFF
--- a/api.py
+++ b/api.py
@@ -20,7 +20,7 @@ from fastapi.security.api_key import APIKeyHeader
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from phone_spam_checker.job_manager import JobManager
+from phone_spam_checker.job_manager import JobManager, SQLiteJobRepository
 from phone_spam_checker.logging_config import configure_logging
 from phone_spam_checker.config import settings
 
@@ -48,7 +48,7 @@ configure_logging(
 )
 logger = logging.getLogger(__name__)
 
-job_manager = JobManager(settings.job_db_path)
+job_manager = JobManager(SQLiteJobRepository(settings.job_db_path))
 job_queue: asyncio.Queue[tuple[str, List[str], str]] = asyncio.Queue()
 
 

--- a/phone_spam_checker/__init__.py
+++ b/phone_spam_checker/__init__.py
@@ -11,7 +11,7 @@ from .infrastructure import (  # noqa: F401
     TruecallerChecker,
     GetContactChecker,
 )
-from .job_manager import JobManager
+from .job_manager import JobManager, JobRepository, SQLiteJobRepository
 from .logging_config import configure_logging
 from .device_client import AndroidDeviceClient
 from .config import settings
@@ -27,6 +27,8 @@ __all__ = [
     "TruecallerChecker",
     "GetContactChecker",
     "JobManager",
+    "JobRepository",
+    "SQLiteJobRepository",
     "configure_logging",
     "AndroidDeviceClient",
     "settings",


### PR DESCRIPTION
## Summary
- add `JobRepository` protocol and `SQLiteJobRepository`
- refactor `JobManager` to delegate operations to a repository
- update API to use `SQLiteJobRepository`
- export repository classes in package init
- adapt tests with mock repository

## Testing
- `pip install --break-system-packages pytest -q`
- `pip install --break-system-packages --no-cache-dir -r requirements.txt -q --ignore-installed`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684183ac052483278f3c64ba099321f5