### PR TITLE
Add device pool for parallel phone checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The application loads its configuration from environment variables. The most imp
 - `KASP_ADB_HOST` / `KASP_ADB_PORT` – address of the device with Kaspersky Who Calls.
 - `TC_ADB_HOST` / `TC_ADB_PORT` – address of the device with Truecaller.
 - `GC_ADB_HOST` / `GC_ADB_PORT` – address of the device with GetContact.
+- `KASP_DEVICES` – comma-separated list of Kaspersky device addresses.
+- `TC_DEVICES` – comma-separated list of Truecaller device addresses.
+- `GC_DEVICES` – comma-separated list of GetContact device addresses.
 - `JOB_DB_PATH` – path to the SQLite file storing job statuses.
 - `PG_HOST` / `PG_PORT` – address of the Postgres server.
 - `PG_DB` – database name.
@@ -28,6 +31,10 @@ The application loads its configuration from environment variables. The most imp
 - `LOG_FILE` – optional path to a file where logs will be written.
 - `WORKER_COUNT` – how many background workers process jobs.
 - `CHECKER_MODULES` – comma-separated list of modules with extra checkers.
+
+`*_DEVICES` variables override the single `*_ADB_HOST`/`*_ADB_PORT` settings and
+allow specifying multiple devices separated by commas. If not set, the host/port
+values are used.
 
 Values can be provided in an `.env` file which is read by `docker-compose`.
 

--- a/phone_spam_checker/config.py
+++ b/phone_spam_checker/config.py
@@ -32,6 +32,9 @@ class Settings:
     log_file: str | None = None
     worker_count: int = 1
     checker_modules: list[str] = field(default_factory=list)
+    kasp_devices: list[str] = field(default_factory=list)
+    tc_devices: list[str] = field(default_factory=list)
+    gc_devices: list[str] = field(default_factory=list)
 
     @property
     def pg_dsn(self) -> str:
@@ -42,7 +45,7 @@ class Settings:
 
     @classmethod
     def from_env(cls) -> "Settings":
-        return cls(
+        cfg = cls(
             api_key=_getenv("API_KEY", ""),
             secret_key=_getenv("SECRET_KEY", ""),
             kasp_adb_host=_getenv("KASP_ADB_HOST", "127.0.0.1"),
@@ -64,7 +67,17 @@ class Settings:
             log_file=_getenv("LOG_FILE", "") or None,
             worker_count=int(_getenv("WORKER_COUNT", "1")),
             checker_modules=[m for m in _getenv("CHECKER_MODULES", "").split(",") if m],
+            kasp_devices=[d for d in _getenv("KASP_DEVICES", "").split(",") if d],
+            tc_devices=[d for d in _getenv("TC_DEVICES", "").split(",") if d],
+            gc_devices=[d for d in _getenv("GC_DEVICES", "").split(",") if d],
         )
+        if not cfg.kasp_devices:
+            cfg.kasp_devices = [f"{cfg.kasp_adb_host}:{cfg.kasp_adb_port}"]
+        if not cfg.tc_devices:
+            cfg.tc_devices = [f"{cfg.tc_adb_host}:{cfg.tc_adb_port}"]
+        if not cfg.gc_devices:
+            cfg.gc_devices = [f"{cfg.gc_adb_host}:{cfg.gc_adb_port}"]
+        return cfg
 
 
 settings = Settings.from_env()

--- a/phone_spam_checker/device_pool.py
+++ b/phone_spam_checker/device_pool.py
@@ -1,0 +1,25 @@
+import threading
+from typing import List
+
+from .exceptions import JobAlreadyRunningError
+
+class DevicePool:
+    """Simple synchronized pool for allocating devices."""
+
+    def __init__(self, devices: List[str]):
+        self._lock = threading.Lock()
+        self._devices = list(devices)
+
+    def acquire(self) -> str:
+        with self._lock:
+            if not self._devices:
+                raise JobAlreadyRunningError("No free device")
+            return self._devices.pop()
+
+    def release(self, device: str) -> None:
+        with self._lock:
+            self._devices.append(device)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._devices)

--- a/phone_spam_checker/job_manager.py
+++ b/phone_spam_checker/job_manager.py
@@ -128,10 +128,10 @@ class SQLiteJobRepository(JobRepository):
             try:
                 data = json.loads(results_json)
                 for entry in data:
-                    status = entry.get("status")
-                    if isinstance(status, str):
+                    st = entry.get("status")
+                    if isinstance(st, str):
                         try:
-                            entry["status"] = CheckStatus(status)
+                            entry["status"] = CheckStatus(st)
                         except Exception:
                             pass
                 results = [PhoneCheckResult(**entry) for entry in data]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ httpx==0.27.0
 PyJWT==2.8.0
 SQLAlchemy==2.0.41
 psycopg2-binary==2.9.10
+pytest-asyncio==0.23.5

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -204,12 +204,10 @@ def test_job_failed_when_device_unreachable(monkeypatch):
 
 
 def test_job_already_running(monkeypatch):
-    class BusyJobManager(DummyJobManager):
-        def ensure_no_running(self, device):
-            raise api.JobAlreadyRunningError("Previous task is still in progress")
+    def busy_new_job(service):
+        raise api.JobAlreadyRunningError("Previous task is still in progress")
 
-    monkeypatch.setattr(api, "job_manager", BusyJobManager())
-    monkeypatch.setattr(api, "_new_job", lambda service: "job123")
+    monkeypatch.setattr(api, "_new_job", busy_new_job)
 
     client = TestClient(api.app)
     headers = _auth_header(client)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,62 @@
+import sys
+import types
+import asyncio
+import contextlib
+import pytest
+
+sys.modules.setdefault("uiautomator2", types.ModuleType("uiautomator2"))
+
+from phone_spam_checker.logging_config import configure_logging
+from phone_spam_checker.config import settings
+
+configure_logging(level=settings.log_level, fmt=settings.log_format, log_file=settings.log_file)
+
+import api
+from phone_spam_checker.job_manager import JobManager, SQLiteJobRepository
+from phone_spam_checker.domain.models import PhoneCheckResult, CheckStatus
+from phone_spam_checker.domain.phone_checker import PhoneChecker
+from phone_spam_checker.device_pool import DevicePool
+
+
+class DummyChecker(PhoneChecker):
+    def launch_app(self) -> bool:
+        return True
+
+    def close_app(self) -> None:
+        pass
+
+    def check_number(self, phone: str) -> PhoneCheckResult:
+        return PhoneCheckResult(phone_number=phone, status=CheckStatus.SAFE)
+
+
+@pytest.mark.asyncio
+async def test_parallel_checks(monkeypatch):
+    repo = SQLiteJobRepository(":memory:")
+    manager = JobManager(repo)
+    monkeypatch.setattr(api, "job_manager", manager)
+    monkeypatch.setattr(api, "get_checker_class", lambda name: DummyChecker)
+    monkeypatch.setattr(api, "_ping_device", lambda *a, **kw: None)
+
+    api.device_pools = {
+        "kaspersky": DevicePool(["dev1", "dev2"]),
+        "truecaller": DevicePool([]),
+        "getcontact": DevicePool([]),
+    }
+
+    j1 = api._new_job("kaspersky")
+    j2 = api._new_job("kaspersky")
+    assert api.job_devices[j1]["kaspersky"] != api.job_devices[j2]["kaspersky"]
+
+    workers = [asyncio.create_task(api._worker()) for _ in range(2)]
+    await api.enqueue_job(j1, ["111"], "kaspersky")
+    await api.enqueue_job(j2, ["222"], "kaspersky")
+    await api.job_queue.join()
+
+    for w in workers:
+        w.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await asyncio.gather(*workers)
+
+    assert manager.get_job(j1)["status"] == "completed"
+    assert manager.get_job(j2)["status"] == "completed"
+


### PR DESCRIPTION
## Summary
- manage Android devices via a synchronized `DevicePool`
- allocate devices when creating jobs and release them when done
- allow configuring multiple devices via new `*_DEVICES` settings
- distribute jobs across available devices
- add integration test for parallel job execution
- update README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684192c3d32c8327adc0fa23e697e22f