### PR TITLE
Add API key checks

### DIFF
--- a/phone_spam_checker/config.py
+++ b/phone_spam_checker/config.py
@@ -81,3 +81,5 @@ class Settings:
 
 
 settings = Settings.from_env()
+if not settings.api_key or not settings.secret_key:
+    raise RuntimeError("API_KEY and SECRET_KEY environment variables are required")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from importlib import util
 from pathlib import Path
 import sys
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -39,3 +40,17 @@ def test_settings_env(monkeypatch):
     assert config.settings.secret_key == "xyz"
     assert config.settings.kasp_adb_host == "host"
     assert config.settings.kasp_adb_port == "1111"
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "xyz")
+    with pytest.raises(RuntimeError):
+        load_config()
+
+
+def test_missing_secret_key(monkeypatch):
+    monkeypatch.setenv("API_KEY", "abc")
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        load_config()


### PR DESCRIPTION
## Summary
- enforce API_KEY and SECRET_KEY presence in `config`
- add tests for missing keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a2a0a8c08327a67f4cf02add8588