### PR TITLE
Add context manager to DevicePool and update API

### DIFF
--- a/phone_spam_checker/device_pool.py
+++ b/phone_spam_checker/device_pool.py
@@ -9,6 +9,7 @@ class DevicePool:
     def __init__(self, devices: List[str]):
         self._lock = threading.Lock()
         self._devices = list(devices)
+        self._local = threading.local()
 
     def acquire(self) -> str:
         with self._lock:
@@ -23,3 +24,22 @@ class DevicePool:
     def __len__(self) -> int:
         with self._lock:
             return len(self._devices)
+
+    # ------------------------------------------------------------------
+    # context manager support
+    # ------------------------------------------------------------------
+    def __enter__(self) -> str:
+        device = self.acquire()
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            stack = []
+            self._local.stack = stack
+        stack.append(device)
+        return device
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        stack = getattr(self._local, "stack", [])
+        if not stack:
+            return
+        device = stack.pop()
+        self.release(device)

--- a/tests/test_device_pool.py
+++ b/tests/test_device_pool.py
@@ -1,0 +1,11 @@
+import pytest
+
+from phone_spam_checker.device_pool import DevicePool
+
+
+def test_device_released_on_exception():
+    pool = DevicePool(["dev1"])
+    with pytest.raises(RuntimeError):
+        with pool:
+            raise RuntimeError("boom")
+    assert len(pool) == 1

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -45,7 +45,6 @@ async def test_parallel_checks(monkeypatch):
 
     j1 = api._new_job("kaspersky")
     j2 = api._new_job("kaspersky")
-    assert api.job_devices[j1]["kaspersky"] != api.job_devices[j2]["kaspersky"]
 
     workers = [asyncio.create_task(api._worker()) for _ in range(2)]
     await api.enqueue_job(j1, ["111"], "kaspersky")
@@ -59,4 +58,5 @@ async def test_parallel_checks(monkeypatch):
 
     assert manager.get_job(j1)["status"] == "completed"
     assert manager.get_job(j2)["status"] == "completed"
+    assert len(api.device_pools["kaspersky"]) == 2
 


### PR DESCRIPTION
## Summary
- implement `__enter__`/`__exit__` in `DevicePool`
- use context manager in worker loop
- simplify job creation
- add regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a4848588832790924a3ccbda4d7b