### PR TITLE
Refactor checkers with new Android base class

### DIFF
--- a/phone_spam_checker/infrastructure/base_checker.py
+++ b/phone_spam_checker/infrastructure/base_checker.py
@@ -1,0 +1,16 @@
+import logging
+
+from ..device_client import AndroidDeviceClient
+from ..domain.phone_checker import PhoneChecker
+
+logger = logging.getLogger(__name__)
+
+
+class AndroidAppChecker(PhoneChecker):
+    """Base class for checkers running on Android devices."""
+
+    def __init__(self, device: str) -> None:
+        super().__init__(device)
+        self.client = AndroidDeviceClient(device)
+        self.d = self.client.d
+

--- a/phone_spam_checker/infrastructure/getcontact.py
+++ b/phone_spam_checker/infrastructure/getcontact.py
@@ -1,9 +1,8 @@
 import logging
 
-from ..device_client import AndroidDeviceClient
+from .base_checker import AndroidAppChecker
 
 from ..domain.models import PhoneCheckResult, CheckStatus
-from ..domain.phone_checker import PhoneChecker
 
 APP_PACKAGE = "app.source.getcontact"
 APP_ACTIVITY = ".ui.starter.StarterActivity"
@@ -24,11 +23,7 @@ LOC_PRIVATE_MODE = {"resourceId": "dialog.privateModeSettings.title"}
 logger = logging.getLogger(__name__)
 
 
-class GetContactChecker(PhoneChecker):
-    def __init__(self, device: str) -> None:
-        super().__init__(device)
-        self.client = AndroidDeviceClient(device)
-        self.d = self.client.d
+class GetContactChecker(AndroidAppChecker):
 
     def launch_app(self) -> bool:
         logger.info("Launching GetContact")

--- a/phone_spam_checker/infrastructure/kaspersky.py
+++ b/phone_spam_checker/infrastructure/kaspersky.py
@@ -1,9 +1,8 @@
 import logging
 
-from ..device_client import AndroidDeviceClient
+from .base_checker import AndroidAppChecker
 
 from ..domain.models import PhoneCheckResult, CheckStatus
-from ..domain.phone_checker import PhoneChecker
 
 APP_PACKAGE = "com.kaspersky.who_calls"
 APP_ACTIVITY = "com.kaspersky.who_calls.LauncherActivityAlias"
@@ -19,11 +18,7 @@ LOC_USEFUL_TEXT = {"textContains": "useful"}
 logger = logging.getLogger(__name__)
 
 
-class KasperskyWhoCallsChecker(PhoneChecker):
-    def __init__(self, device: str) -> None:
-        super().__init__(device)
-        self.client = AndroidDeviceClient(device)
-        self.d = self.client.d
+class KasperskyWhoCallsChecker(AndroidAppChecker):
 
     def launch_app(self) -> bool:
         logger.info("Launching application")

--- a/phone_spam_checker/infrastructure/truecaller.py
+++ b/phone_spam_checker/infrastructure/truecaller.py
@@ -1,9 +1,8 @@
 import logging
 
-from ..device_client import AndroidDeviceClient
+from .base_checker import AndroidAppChecker
 
 from ..domain.models import PhoneCheckResult, CheckStatus
-from ..domain.phone_checker import PhoneChecker
 
 APP_PACKAGE = "com.truecaller"
 APP_ACTIVITY = "com.truecaller.ui.TruecallerInit"
@@ -19,11 +18,7 @@ LOC_PHONE_NUMBER = {"resourceId": "com.truecaller:id/phoneNumber"}
 logger = logging.getLogger(__name__)
 
 
-class TruecallerChecker(PhoneChecker):
-    def __init__(self, device: str) -> None:
-        super().__init__(device)
-        self.client = AndroidDeviceClient(device)
-        self.d = self.client.d
+class TruecallerChecker(AndroidAppChecker):
 
     def launch_app(self) -> bool:
         logger.info("Launching Truecaller")


### PR DESCRIPTION
## Summary
- add `AndroidAppChecker` for common Android client handling
- refactor Kaspersky, Truecaller, and GetContact checkers to inherit from it

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a847b5108327a3c917d3e5e00f02