### PR TITLE
Refactor API structure

### DIFF
--- a/phone_spam_checker/api/__init__.py
+++ b/phone_spam_checker/api/__init__.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI
+
+from phone_spam_checker.exceptions import DeviceConnectionError
+
+from .routes import router
+from .jobs import start_background_tasks, device_error_handler, exception_middleware
+from .schemas import CheckResult
+from phone_spam_checker.domain.models import CheckStatus
+from . import jobs, auth  # re-export for convenience
+
+app = FastAPI(title="Phone Checker API", version="2.0")
+
+app.include_router(router)
+app.add_event_handler("startup", start_background_tasks)
+app.add_exception_handler(DeviceConnectionError, device_error_handler)
+app.middleware("http")(exception_middleware)
+
+__all__ = [
+    "app",
+    "CheckResult",
+    "CheckStatus",
+]

--- a/phone_spam_checker/api/auth.py
+++ b/phone_spam_checker/api/auth.py
@@ -1,0 +1,33 @@
+import jwt
+from jwt import PyJWTError
+from fastapi import HTTPException, Security, Depends
+from fastapi.security.api_key import APIKeyHeader
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+from phone_spam_checker.config import settings
+
+API_KEY_NAME = "X-API-Key"
+api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _create_token() -> str:
+    return jwt.encode({"sub": "api"}, settings.secret_key, algorithm="HS256")
+
+
+async def login(api_key: str = Security(api_key_header)) -> dict:
+    if not settings.api_key or api_key != settings.api_key:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return {"access_token": _create_token()}
+
+
+async def get_token(
+    credentials: HTTPAuthorizationCredentials = Security(bearer_scheme),
+) -> str:
+    if credentials is None:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    try:
+        jwt.decode(credentials.credentials, settings.secret_key, algorithms=["HS256"])
+    except PyJWTError:
+        raise HTTPException(status_code=403, detail="Invalid token")
+    return credentials.credentials

--- a/phone_spam_checker/api/routes.py
+++ b/phone_spam_checker/api/routes.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+
+from .auth import login, get_token
+from .schemas import CheckRequest, CheckResult, JobResponse, StatusResponse
+from . import jobs
+from phone_spam_checker.exceptions import JobAlreadyRunningError
+
+router = APIRouter()
+
+router.post("/login")(login)
+
+
+@router.post("/check_numbers", response_model=JobResponse)
+def submit_check(
+    request: CheckRequest,
+    background_tasks: BackgroundTasks,
+    _: str = Depends(get_token),
+) -> JobResponse:
+    try:
+        job_id = jobs._new_job(request.service)
+    except JobAlreadyRunningError as e:
+        raise HTTPException(status_code=429, detail=str(e)) from e
+    if request.service not in {"auto", "kaspersky", "truecaller", "getcontact"}:
+        raise HTTPException(status_code=400, detail="Unknown service")
+
+    background_tasks.add_task(jobs.enqueue_job, job_id, request.numbers, request.service)
+    return JobResponse(job_id=job_id)
+
+
+@router.get("/status/{job_id}", response_model=StatusResponse)
+def get_status(job_id: str, _: str = Depends(get_token)) -> StatusResponse:
+    job = jobs.job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job ID not found")
+    return StatusResponse(
+        job_id=job_id,
+        status=job["status"],
+        results=job.get("results"),
+        error=job.get("error"),
+    )

--- a/phone_spam_checker/api/schemas.py
+++ b/phone_spam_checker/api/schemas.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, field_validator
+
+from phone_spam_checker.domain.models import CheckStatus
+from phone_spam_checker.validators import validate_phone_number
+
+
+class CheckRequest(BaseModel):
+    numbers: List[str]
+    service: str = "auto"  # 'auto', 'kaspersky', 'truecaller', 'getcontact'
+
+    @field_validator("numbers")
+    @classmethod
+    def validate_numbers(cls, v: List[str]) -> List[str]:
+        return [validate_phone_number(num) for num in v]
+
+
+class JobResponse(BaseModel):
+    job_id: str
+
+
+class CheckResult(BaseModel):
+    phone_number: str
+    status: CheckStatus
+    details: str = ""
+
+
+class StatusResponse(BaseModel):
+    job_id: str
+    status: str
+    results: Optional[List[CheckResult]] = None
+    error: Optional[str] = None


### PR DESCRIPTION
## Summary
- organize API code into a package
- add modules for auth, jobs and routes
- adjust imports in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a99f9268832782a35cdb9f9b38d1