### PR TITLE
Add distributed pool with Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ LOG_LEVEL=INFO
 LOG_FORMAT=%(asctime)s %(levelname)s %(name)s: %(message)s
 LOG_FILE=
 WORKER_COUNT=1
+USE_REDIS=1
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/README.md
+++ b/README.md
@@ -31,12 +31,17 @@ The application loads its configuration from environment variables. The most imp
 - `LOG_FILE` – optional path to a file where logs will be written.
 - `WORKER_COUNT` – how many background workers process jobs.
 - `CHECKER_MODULES` – comma-separated list of modules with extra checkers.
+- `USE_REDIS` – set to `1` to enable distributed mode using Redis.
+- `REDIS_HOST` / `REDIS_PORT` – address of the Redis server.
 
 `*_DEVICES` variables override the single `*_ADB_HOST`/`*_ADB_PORT` settings and
 allow specifying multiple devices separated by commas. If not set, the host/port
 values are used.
 
 Values can be provided in an `.env` file which is read by `docker-compose`.
+
+When `USE_REDIS` is enabled the service stores device pools and job queues in
+Redis allowing multiple instances to work together.
 
 ## Running with Docker
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Values can be provided in an `.env` file which is read by `docker-compose`.
 
 When `USE_REDIS` is enabled the service stores device pools and job queues in
 Redis allowing multiple instances to work together.
+The provided `docker-compose` files run a Redis container and enable this mode by default.
 
 ## Running with Docker
 
-A simple way to start the service is via `docker-compose` which will launch the API and a Postgres instance:
+A simple way to start the service is via `docker-compose` which will launch the API along with Postgres and Redis:
 
 ```bash
 # create .env file with all required variables

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,12 @@ services:
       - PG_DB=${PG_DB}
       - PG_USER=${PG_USER}
       - PG_PASSWORD=${PG_PASSWORD}
+      - USE_REDIS=1
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      - db
+      - redis
     labels:
       caddy: telephony.visotsky.com
       caddy.reverse_proxy: "{{upstreams 8000}}"
@@ -51,8 +57,19 @@ services:
     ports:
       - "5432:5432"
 
+  redis:
+    image: redis:7
+    container_name: phone-checker-redis
+    networks: [caddy]
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+    ports:
+      - "6379:6379"
+
 volumes:
   pgdata:
+  redisdata:
 
 # .env file next to this compose:
 # API_KEY=your-super-secret-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,12 @@ services:
       - PG_DB=${PG_DB}
       - PG_USER=${PG_USER}
       - PG_PASSWORD=${PG_PASSWORD}
+      - USE_REDIS=1
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
     depends_on:
       - db
+      - redis
 
   db:
     image: postgres:16
@@ -46,8 +50,18 @@ services:
     ports:
       - "5432:5432"
 
+  redis:
+    image: redis:7
+    container_name: phone-checker-redis
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+    ports:
+      - "6379:6379"
+
 volumes:
   pgdata:
+  redisdata:
 
 # .env file next to this compose:
 # API_KEY=your-super-secret-key

--- a/phone_spam_checker/api/jobs.py
+++ b/phone_spam_checker/api/jobs.py
@@ -14,7 +14,11 @@ from .schemas import CheckResult
 from phone_spam_checker.domain.phone_checker import PhoneChecker
 from phone_spam_checker.exceptions import DeviceConnectionError, JobAlreadyRunningError
 from phone_spam_checker.job_manager import JobManager
-from phone_spam_checker.dependencies import get_job_manager, get_device_pool
+from phone_spam_checker.dependencies import (
+    get_job_manager,
+    get_device_pool,
+    get_job_queue,
+)
 from phone_spam_checker.logging_config import configure_logging
 from phone_spam_checker.registry import (
     get_checker_class,
@@ -28,7 +32,7 @@ for mod in filter(None, getattr(settings, "checker_modules", [])):
     load_checker_module(mod)
 logger = logging.getLogger(__name__)
 
-job_queue: asyncio.Queue[tuple[str, List[str], str]] = asyncio.Queue()
+job_queue = get_job_queue()
 
 
 async def enqueue_job(job_id: str, numbers: List[str], service: str) -> None:

--- a/phone_spam_checker/config.py
+++ b/phone_spam_checker/config.py
@@ -35,6 +35,9 @@ class Settings:
     kasp_devices: list[str] = field(default_factory=list)
     tc_devices: list[str] = field(default_factory=list)
     gc_devices: list[str] = field(default_factory=list)
+    use_redis: bool = False
+    redis_host: str = "127.0.0.1"
+    redis_port: str = "6379"
 
     @property
     def pg_dsn(self) -> str:
@@ -70,6 +73,9 @@ class Settings:
             kasp_devices=[d for d in _getenv("KASP_DEVICES", "").split(",") if d],
             tc_devices=[d for d in _getenv("TC_DEVICES", "").split(",") if d],
             gc_devices=[d for d in _getenv("GC_DEVICES", "").split(",") if d],
+            use_redis=_getenv("USE_REDIS", "0") == "1",
+            redis_host=_getenv("REDIS_HOST", "127.0.0.1"),
+            redis_port=_getenv("REDIS_PORT", "6379"),
         )
         if not cfg.kasp_devices:
             cfg.kasp_devices = [f"{cfg.kasp_adb_host}:{cfg.kasp_adb_port}"]

--- a/phone_spam_checker/dependencies.py
+++ b/phone_spam_checker/dependencies.py
@@ -1,11 +1,19 @@
-from typing import Dict
+from typing import Dict, Any
+import asyncio
 
 from .config import settings
 from .device_pool import DevicePool
+from .distributed_pool import RedisDevicePool, RedisJobQueue
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None  # type: ignore
 from .job_manager import JobManager, SQLiteJobRepository, PostgresJobRepository
 
 _job_manager: JobManager | None = None
 _device_pools: Dict[str, DevicePool] = {}
+_job_queue: asyncio.Queue | RedisJobQueue | None = None
+_redis_client: Any | None = None  # redis.Redis when available
 
 
 def get_job_manager() -> JobManager:
@@ -19,6 +27,19 @@ def get_job_manager() -> JobManager:
     return _job_manager
 
 
+def _get_redis() -> "redis.Redis":
+    global _redis_client
+    if _redis_client is None:
+        if redis is None:
+            raise RuntimeError("redis package is required for distributed mode")
+        _redis_client = redis.Redis(
+            host=settings.redis_host,
+            port=int(settings.redis_port),
+            decode_responses=True,
+        )
+    return _redis_client
+
+
 def get_device_pool(service: str) -> DevicePool:
     global _device_pools
     pool = _device_pools.get(service)
@@ -28,6 +49,21 @@ def get_device_pool(service: str) -> DevicePool:
             "truecaller": settings.tc_devices,
             "getcontact": settings.gc_devices,
         }
-        pool = DevicePool(devices_map[service])
+        if settings.use_redis:
+            client = _get_redis()
+            pool = RedisDevicePool(f"pool:{service}", devices_map[service], client)
+        else:
+            pool = DevicePool(devices_map[service])
         _device_pools[service] = pool
     return pool
+
+
+def get_job_queue() -> asyncio.Queue | RedisJobQueue:
+    global _job_queue
+    if _job_queue is None:
+        if settings.use_redis:
+            client = _get_redis()
+            _job_queue = RedisJobQueue("job_queue", client)
+        else:
+            _job_queue = asyncio.Queue()
+    return _job_queue

--- a/phone_spam_checker/distributed_pool.py
+++ b/phone_spam_checker/distributed_pool.py
@@ -1,0 +1,100 @@
+import asyncio
+import json
+import threading
+from typing import List, Tuple
+
+from .exceptions import JobAlreadyRunningError
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None  # type: ignore
+
+
+class RedisDevicePool:
+    """Distributed device pool backed by Redis lists."""
+
+    def __init__(self, name: str, devices: List[str], client: "redis.Redis") -> None:
+        if redis is None:
+            raise RuntimeError("redis package is required for RedisDevicePool")
+        self._name = name
+        self._redis = client
+        self._local = threading.local()
+        if devices and not self._redis.exists(name):
+            self._redis.rpush(name, *devices)
+
+    def acquire(self, timeout: int = 1) -> str:
+        result = self._redis.blpop(self._name, timeout=timeout)
+        if result is None:
+            raise JobAlreadyRunningError("No free device")
+        value = result[1]
+        if isinstance(value, bytes):
+            value = value.decode()
+        return value
+
+    def release(self, device: str) -> None:
+        self._redis.rpush(self._name, device)
+
+    def __len__(self) -> int:
+        return int(self._redis.llen(self._name))
+
+    # ------------------------------------------------------------------
+    # context manager support
+    # ------------------------------------------------------------------
+    def __enter__(self) -> str:
+        device = self.acquire()
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            stack = []
+            self._local.stack = stack
+        stack.append(device)
+        return device
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        stack = getattr(self._local, "stack", [])
+        if not stack:
+            return
+        device = stack.pop()
+        self.release(device)
+
+
+class RedisJobQueue:
+    """Async job queue stored in Redis."""
+
+    def __init__(self, name: str, client: "redis.Redis") -> None:
+        if redis is None:
+            raise RuntimeError("redis package is required for RedisJobQueue")
+        self._name = name
+        self._redis = client
+        self._pending = 0
+        self._event = asyncio.Event()
+        self._event.set()
+        self._lock = asyncio.Lock()
+
+    async def put(self, item: Tuple[str, List[str], str]) -> None:
+        data = json.dumps(item)
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._redis.rpush, self._name, data)
+        async with self._lock:
+            self._pending += 1
+            self._event.clear()
+
+    async def get(self) -> Tuple[str, List[str], str]:
+        loop = asyncio.get_event_loop()
+        data = await loop.run_in_executor(
+            None, lambda: self._redis.blpop(self._name)[1]
+        )
+        job_id, numbers, service = json.loads(data)
+        return job_id, numbers, service
+
+    def task_done(self) -> None:
+        async def _update() -> None:
+            async with self._lock:
+                self._pending -= 1
+                if self._pending <= 0:
+                    self._event.set()
+
+        asyncio.create_task(_update())
+
+    async def join(self) -> None:
+        await self._event.wait()

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ PyJWT==2.8.0
 SQLAlchemy==2.0.41
 psycopg2-binary==2.9.10
 pytest-asyncio==0.23.5
+redis==5.0.4

--- a/tests/test_distributed_pool.py
+++ b/tests/test_distributed_pool.py
@@ -1,0 +1,47 @@
+import asyncio
+import pytest
+
+from phone_spam_checker.distributed_pool import RedisDevicePool, RedisJobQueue
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    def exists(self, key):
+        return key in self.data
+
+    def rpush(self, key, *values):
+        self.data.setdefault(key, []).extend(values)
+
+    def blpop(self, key, timeout=0):
+        lst = self.data.get(key, [])
+        if not lst:
+            return None
+        return (key, lst.pop(0))
+
+    def llen(self, key):
+        return len(self.data.get(key, []))
+
+
+def test_redis_device_pool():
+    client = FakeRedis()
+    pool = RedisDevicePool("pool:test", ["dev1"], client)
+    with pool as dev:
+        assert dev == "dev1"
+        assert len(pool) == 0
+    assert len(pool) == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_job_queue():
+    client = FakeRedis()
+    q = RedisJobQueue("jobs", client)
+    await q.put(("job", ["1"], "svc"))
+    job_id, nums, svc = await q.get()
+    assert job_id == "job"
+    assert nums == ["1"]
+    assert svc == "svc"
+    q.task_done()
+    await q.join()
+


### PR DESCRIPTION
## Summary
- add Redis based device pool and job queue implementations
- configure optional Redis usage via new settings
- document new environment variables
- test distributed pool functionality with stubbed Redis
- wire new job queue in the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841afe3b4008327a36219aaf4343842