### PR TITLE
Switch config to pydantic BaseSettings

### DIFF
--- a/phone_spam_checker/config.py
+++ b/phone_spam_checker/config.py
@@ -1,20 +1,18 @@
 """Project configuration loaded from environment variables."""
 
-from dataclasses import dataclass, field
-import os
+from typing import Any, List
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-def _getenv(key: str, default: str) -> str:
-    """Read environment variable in a case-insensitive manner."""
-    return os.getenv(key, os.getenv(key.lower(), default))
-
-
-@dataclass
-class Settings:
+class Settings(BaseSettings):
     """Application configuration."""
 
-    api_key: str = ""
-    secret_key: str = ""
+    model_config = SettingsConfigDict(case_sensitive=False)
+
+    api_key: str
+    secret_key: str
     kasp_adb_host: str = "127.0.0.1"
     kasp_adb_port: str = "5555"
     tc_adb_host: str = "127.0.0.1"
@@ -31,13 +29,34 @@ class Settings:
     log_format: str = "%(asctime)s %(levelname)s %(name)s: %(message)s"
     log_file: str | None = None
     worker_count: int = 1
-    checker_modules: list[str] = field(default_factory=list)
-    kasp_devices: list[str] = field(default_factory=list)
-    tc_devices: list[str] = field(default_factory=list)
-    gc_devices: list[str] = field(default_factory=list)
+    checker_modules: List[str] = []
+    kasp_devices: List[str] = []
+    tc_devices: List[str] = []
+    gc_devices: List[str] = []
     use_redis: bool = False
     redis_host: str = "127.0.0.1"
     redis_port: str = "6379"
+
+    @field_validator(
+        "checker_modules",
+        "kasp_devices",
+        "tc_devices",
+        "gc_devices",
+        mode="before",
+    )
+    @classmethod
+    def _split_csv(cls, v: Any) -> List[str]:
+        if isinstance(v, str):
+            return [item for item in v.split(",") if item]
+        return list(v) if v else []
+
+    def model_post_init(self, __context: Any) -> None:  # type: ignore[override]
+        if not self.kasp_devices:
+            self.kasp_devices = [f"{self.kasp_adb_host}:{self.kasp_adb_port}"]
+        if not self.tc_devices:
+            self.tc_devices = [f"{self.tc_adb_host}:{self.tc_adb_port}"]
+        if not self.gc_devices:
+            self.gc_devices = [f"{self.gc_adb_host}:{self.gc_adb_port}"]
 
     @property
     def pg_dsn(self) -> str:
@@ -46,46 +65,13 @@ class Settings:
             f"@{self.pg_host}:{self.pg_port}/{self.pg_db}"
         )
 
-    @classmethod
-    def from_env(cls) -> "Settings":
-        cfg = cls(
-            api_key=_getenv("API_KEY", ""),
-            secret_key=_getenv("SECRET_KEY", ""),
-            kasp_adb_host=_getenv("KASP_ADB_HOST", "127.0.0.1"),
-            kasp_adb_port=_getenv("KASP_ADB_PORT", "5555"),
-            tc_adb_host=_getenv("TC_ADB_HOST", "127.0.0.1"),
-            tc_adb_port=_getenv("TC_ADB_PORT", "5556"),
-            gc_adb_host=_getenv("GC_ADB_HOST", "127.0.0.1"),
-            gc_adb_port=_getenv("GC_ADB_PORT", "5557"),
-            job_db_path=_getenv("JOB_DB_PATH", "jobs.sqlite"),
-            pg_host=_getenv("PG_HOST", ""),
-            pg_port=_getenv("PG_PORT", "5432"),
-            pg_db=_getenv("PG_DB", "phonechecker"),
-            pg_user=_getenv("PG_USER", "postgres"),
-            pg_password=_getenv("PG_PASSWORD", "postgres"),
-            log_level=_getenv("LOG_LEVEL", "INFO"),
-            log_format=_getenv(
-                "LOG_FORMAT", "%(asctime)s %(levelname)s %(name)s: %(message)s"
-            ),
-            log_file=_getenv("LOG_FILE", "") or None,
-            worker_count=int(_getenv("WORKER_COUNT", "1")),
-            checker_modules=[m for m in _getenv("CHECKER_MODULES", "").split(",") if m],
-            kasp_devices=[d for d in _getenv("KASP_DEVICES", "").split(",") if d],
-            tc_devices=[d for d in _getenv("TC_DEVICES", "").split(",") if d],
-            gc_devices=[d for d in _getenv("GC_DEVICES", "").split(",") if d],
-            use_redis=_getenv("USE_REDIS", "0") == "1",
-            redis_host=_getenv("REDIS_HOST", "127.0.0.1"),
-            redis_port=_getenv("REDIS_PORT", "6379"),
-        )
-        if not cfg.kasp_devices:
-            cfg.kasp_devices = [f"{cfg.kasp_adb_host}:{cfg.kasp_adb_port}"]
-        if not cfg.tc_devices:
-            cfg.tc_devices = [f"{cfg.tc_adb_host}:{cfg.tc_adb_port}"]
-        if not cfg.gc_devices:
-            cfg.gc_devices = [f"{cfg.gc_adb_host}:{cfg.gc_adb_port}"]
-        return cfg
 
+try:
+    settings = Settings()
+except Exception as exc:  # ValidationError or others
+    raise RuntimeError(
+        "API_KEY and SECRET_KEY environment variables are required"
+    ) from exc
 
-settings = Settings.from_env()
 if not settings.api_key or not settings.secret_key:
     raise RuntimeError("API_KEY and SECRET_KEY environment variables are required")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ packaging==25.0
 pillow==11.2.1
 py==1.11.0
 pydantic==2.11.4
+pydantic-settings==2.2.1
 pydantic_core==2.33.2
 requests==2.32.3
 retry==0.9.2


### PR DESCRIPTION
## Summary
- refactor `Settings` to inherit from `pydantic_settings.BaseSettings`
- ensure API_KEY and SECRET_KEY are required
- parse comma-separated env vars via validators
- add `pydantic-settings` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b36d901c832789c6b49458bbba72