### PR TITLE
Add explicit initialization step

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ export SECRET_KEY=your-secret
 uvicorn phone_spam_checker.api:app --host 0.0.0.0 --port 8000
 ```
 
+`phone_spam_checker.api` автоматически настраивает логирование и
+регистрирует встроенные чекеры при старте приложения. Если вы
+используете библиотеку в собственной точке входа, вызовите
+`phone_spam_checker.bootstrap.initialize()` перед запуском сервиса.
+
 Before starting, ensure ADB can reach the devices:
 
 ```bash
@@ -118,6 +123,9 @@ python -m scripts.phone_checker_cli SERVICE --input phones.txt --output results.
 ```
 
 Replace `SERVICE` with `kaspersky`, `truecaller` or `getcontact`. Any additional arguments are passed to the chosen checker.
+
+В сценариях командной строки инициализация выполняется автоматически,
+поэтому достаточно запустить скрипт, как показано выше.
 
 
 ## Tests

--- a/phone_spam_checker/__init__.py
+++ b/phone_spam_checker/__init__.py
@@ -16,6 +16,7 @@ from .job_manager import (
 from .logging_config import configure_logging
 from .device_client import AndroidDeviceClient
 from .config import settings
+from .bootstrap import initialize
 
 __all__ = [
     "PhoneCheckResult",
@@ -32,5 +33,6 @@ __all__ = [
     "PostgresJobRepository",
     "configure_logging",
     "AndroidDeviceClient",
+    "initialize",
     "settings",
 ]

--- a/phone_spam_checker/api/jobs.py
+++ b/phone_spam_checker/api/jobs.py
@@ -19,17 +19,9 @@ from phone_spam_checker.dependencies import (
     get_device_pool,
     get_job_queue,
 )
-from phone_spam_checker.logging_config import configure_logging
-from phone_spam_checker.registry import (
-    get_checker_class,
-    register_default_checkers,
-    load_checker_module,
-)
+from phone_spam_checker.registry import get_checker_class
+from phone_spam_checker.bootstrap import initialize
 
-configure_logging(level=settings.log_level, fmt=settings.log_format, log_file=settings.log_file)
-register_default_checkers()
-for mod in filter(None, getattr(settings, "checker_modules", [])):
-    load_checker_module(mod)
 logger = logging.getLogger(__name__)
 
 job_queue = get_job_queue()
@@ -74,6 +66,7 @@ async def cleanup_jobs() -> None:
 
 
 async def start_background_tasks() -> None:
+    initialize()
     asyncio.create_task(cleanup_jobs())
     services = ["kaspersky", "truecaller", "getcontact"]
     for svc in services:

--- a/phone_spam_checker/bootstrap.py
+++ b/phone_spam_checker/bootstrap.py
@@ -1,0 +1,15 @@
+from .logging_config import configure_logging
+from .registry import register_default_checkers, load_checker_module
+from .config import settings
+
+
+def initialize() -> None:
+    """Configure logging and register available phone checkers."""
+    configure_logging(
+        level=settings.log_level,
+        fmt=settings.log_format,
+        log_file=settings.log_file,
+    )
+    register_default_checkers()
+    for mod in filter(None, getattr(settings, "checker_modules", [])):
+        load_checker_module(mod)

--- a/scripts/phone_checker_cli.py
+++ b/scripts/phone_checker_cli.py
@@ -1,13 +1,9 @@
 from phone_spam_checker.cli_base import parse_service_args, run_checker
-from phone_spam_checker.registry import register_default_checkers, load_checker_module
-from phone_spam_checker.config import settings
-
-register_default_checkers()
-for mod in filter(None, getattr(settings, "checker_modules", [])):
-    load_checker_module(mod)
+from phone_spam_checker.bootstrap import initialize
 
 
 def main(argv: list[str] | None = None) -> int:
+    initialize()
     service, rest = parse_service_args(argv)
     return run_checker(service, rest)
 


### PR DESCRIPTION
## Summary
- add `bootstrap.initialize` for logging and checker setup
- call the initializer from background tasks and CLI entry point
- expose `initialize` in the package API
- document initialization in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b8741d8083279b577434e2fed6f4