### PR TITLE
Add worker error handling

### DIFF
--- a/phone_spam_checker/api/jobs.py
+++ b/phone_spam_checker/api/jobs.py
@@ -57,6 +57,9 @@ async def _worker() -> None:
                     )
         except JobAlreadyRunningError as exc:
             _fail_job(job_id, str(exc), job_manager)
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logger.exception("Worker error for job %s", job_id)
+            _fail_job(job_id, str(exc), job_manager)
         finally:
             job_queue.task_done()
 


### PR DESCRIPTION
## Summary
- handle unexpected errors in the background worker
- ensure job queue is recreated per test
- test worker resilience against failures

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b9a0a5e88327b075d5d9db8d9dad